### PR TITLE
Bugfix/crash with no root param

### DIFF
--- a/.github/workflows/ReleaseNotes.md
+++ b/.github/workflows/ReleaseNotes.md
@@ -1,8 +1,7 @@
 ## What's Changed
-* Build and Release pipelines to help keep everything up to date and automatic
-* Fixed a bug in Windows paths causing the application to incorrectly map root folders
-* Enabled asynchronous operation for a tiny speed improvement and to make way for future performance improvements
-* New command line argument parsing. `--help` and `--version` now available as options!
+* Build pipeline now includes bugfix branches
+* Fixed a bug throwing a Null Reference Exception when optional parameter -r was not used
+* Fixed a bug that would write to the incorrect file when log parameter did not include trailing slash
 
 ## Known Bugs
 * None! If you encounter any bugs, please open an [issue](https://github.com/johnkiddjr/PlexMatch-File-Generator/issues/new)!

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - feature/*
+      - bugfix/*
   pull_request:
     branches:
       - develop

--- a/PlexMatchGenerator/Helpers/ArgumentHelper.cs
+++ b/PlexMatchGenerator/Helpers/ArgumentHelper.cs
@@ -8,6 +8,15 @@ namespace PlexMatchGenerator.Helpers
     {
         public static GeneratorOptions ProcessCommandLineResults(string plexToken, string plexUrl, List<string> rootPaths, string logPath)
         {
+            //ensure we end the path with a slash
+            if (!logPath.EndsWith("\\") && !logPath.EndsWith('/'))
+            {
+                //make sure we use the correct slash if we need to use it
+                bool useBackslash = logPath.Count(x => x.Equals('\\')) > logPath.Count(x => x.Equals('/'));
+
+                logPath += useBackslash ? "\\" : "/";
+            }
+
             return new GeneratorOptions
             {
                 LogPath = logPath,
@@ -21,7 +30,7 @@ namespace PlexMatchGenerator.Helpers
         {
             if (!rootMaps.Any())
             {
-                return null;
+                return new List<RootPathOptions>();
             }
 
             var rootPathMaps = new List<RootPathOptions>();

--- a/PlexMatchGenerator/Services/IGeneratorService.cs
+++ b/PlexMatchGenerator/Services/IGeneratorService.cs
@@ -126,7 +126,7 @@ namespace PlexMatchGenerator.Services
                                         mediaPath = mediaPath.Replace(rootPath.PlexRootPath, rootPath.HostRootPath);
                                         break;
                                     }
-                                }
+                                }                                
 
                                 if (Directory.Exists(mediaPath))
                                 {


### PR DESCRIPTION
Fixes #24 (null reference when not using -r optional parameter)
Fixes issue with logs where they'd be written to the wrong directory if a trailing slash wasn't included
Adds builds for bugfix branches