### PR TITLE
Merge Develop to Main - Bugfixes crash with no root param

### DIFF
--- a/.github/workflows/ReleaseNotes.md
+++ b/.github/workflows/ReleaseNotes.md
@@ -1,8 +1,7 @@
 ## What's Changed
-* Build and Release pipelines to help keep everything up to date and automatic
-* Fixed a bug in Windows paths causing the application to incorrectly map root folders
-* Enabled asynchronous operation for a tiny speed improvement and to make way for future performance improvements
-* New command line argument parsing. `--help` and `--version` now available as options!
+* Build pipeline now includes bugfix branches
+* Fixed a bug throwing a Null Reference Exception when optional parameter -r was not used
+* Fixed a bug that would write to the incorrect file when log parameter did not include trailing slash
 
 ## Known Bugs
 * None! If you encounter any bugs, please open an [issue](https://github.com/johnkiddjr/PlexMatch-File-Generator/issues/new)!

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - feature/*
+      - bugfix/*
   pull_request:
     branches:
       - develop

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,10 +13,12 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main, develop ]
+    branches:
+      - feature/*
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ main ]
+    branches:
+      - develop
+      - main
   schedule:
     - cron: '27 2 * * 2'
 

--- a/PlexMatchGenerator/Helpers/ArgumentHelper.cs
+++ b/PlexMatchGenerator/Helpers/ArgumentHelper.cs
@@ -8,6 +8,15 @@ namespace PlexMatchGenerator.Helpers
     {
         public static GeneratorOptions ProcessCommandLineResults(string plexToken, string plexUrl, List<string> rootPaths, string logPath)
         {
+            //ensure we end the path with a slash
+            if (!logPath.EndsWith("\\") && !logPath.EndsWith('/'))
+            {
+                //make sure we use the correct slash if we need to use it
+                bool useBackslash = logPath.Count(x => x.Equals('\\')) > logPath.Count(x => x.Equals('/'));
+
+                logPath += useBackslash ? "\\" : "/";
+            }
+
             return new GeneratorOptions
             {
                 LogPath = logPath,
@@ -21,7 +30,7 @@ namespace PlexMatchGenerator.Helpers
         {
             if (!rootMaps.Any())
             {
-                return null;
+                return new List<RootPathOptions>();
             }
 
             var rootPathMaps = new List<RootPathOptions>();

--- a/PlexMatchGenerator/Services/IGeneratorService.cs
+++ b/PlexMatchGenerator/Services/IGeneratorService.cs
@@ -126,7 +126,7 @@ namespace PlexMatchGenerator.Services
                                         mediaPath = mediaPath.Replace(rootPath.PlexRootPath, rootPath.HostRootPath);
                                         break;
                                     }
-                                }
+                                }                                
 
                                 if (Directory.Exists(mediaPath))
                                 {

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This application generates a .plexmatch file in the directory of all shows and movies added to your Plex Server. This is especially useful for migrating storage devices if you have some shows that needed a custom match.
 
 # Usage
-The command is expecting 2 arguments from the command line, it will prompt for these values if you do not provide them
+The command is expecting 2 arguments from the command line
 - Plex Server Token (-t or --token)
 - Plex Server Url (-u or --url)
 
@@ -15,6 +15,10 @@ For information on how to get your Plex token, see this support link: https://su
 - Set log path (-l or --log)
   - This will output the log to file at the path specified, log file will be named `plexmatch.log` in the directory specified. The path specified must exist! If this option is not specified, no log file will be output.
   - Usage: -l /home/user/logs
+- Get version (--version)
+  - This will output the version of the executable being run
+- View help (--help)
+  - This will output the parameter help
 
 ## Examples
 
@@ -48,4 +52,5 @@ Contributions are welcome!
 - Fork the repo
 - Make your change
 - Submit a Pull Request, Ensure to include details of what problem is fixed, what is improved, etc. If it is in response to an issue, tag the issue on the PR
+- Submit your PR to merge into the Develop branch, merge requests to the main branch will be denied
 - Respond to and/or make changes based on PR comments


### PR DESCRIPTION
This merge includes:

* Fix for bug that throws exception when optional -r param is not used
* Fix for bug where not using trailing slashes caused weird file names for log